### PR TITLE
[#1] Add unit tests for NoAllocStringReplace

### DIFF
--- a/core/src/main/java/com/elefana/util/NoAllocStringReplace.java
+++ b/core/src/main/java/com/elefana/util/NoAllocStringReplace.java
@@ -15,7 +15,9 @@
  ******************************************************************************/
 package com.elefana.util;
 
+import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Stream;
 
 public class NoAllocStringReplace {
 	private static final CumulativeAverage AVG_ARRAY_SIZE = new CumulativeAverage(16);
@@ -81,7 +83,10 @@ public class NoAllocStringReplace {
 		}
 		for(int i = 0; i < length; i++) {
 			for(int j = 0; j < search.length; j++) {
-				if(str[i] != search[j].charAt(0)) {
+				if(search[j] == null || replace[j] == null) {
+					continue;
+				}
+				if(search[j].isEmpty()) {
 					continue;
 				}
 				if(search[j].length() > length - i) {
@@ -89,7 +94,7 @@ public class NoAllocStringReplace {
 				}
 
 				boolean match = true;
-				for(int k = 1; k < search[j].length() && i + k < length; k++) {
+				for(int k = 0; k < search[j].length() && i + k < length; k++) {
 					if(str[i + k] != search[j].charAt(k)) {
 						match = false;
 						break;
@@ -100,7 +105,6 @@ public class NoAllocStringReplace {
 					i += replace[j].length() - 1;
 				}
 			}
-
 			escapeUnicode(i);
 		}
 	}
@@ -134,7 +138,7 @@ public class NoAllocStringReplace {
 			length -= search.length() - replace.length();
 
 			final int remainder = oldLength - (index + search.length());
-			if(remainder <= 0) {
+			if(remainder < 0) {
 				return;
 			}
 			replace.getChars(0, replace.length(), str, index);
@@ -156,16 +160,20 @@ public class NoAllocStringReplace {
 	}
 
 	public static boolean contains(String str, String [] search) {
+		if(str == null || search == null)
+			return false;
+
 		for(int i = 0; i < str.length(); i++) {
 			for(int j = 0; j < search.length; j++) {
+				if(search[j] == null) {
+					continue;
+				}
 				if(search[j].isEmpty()) {
 					continue;
 				}
-				if(str.charAt(i) != search[j].charAt(0)) {
-					continue;
-				}
+
 				boolean match = true;
-				for(int k = 1; k < search[j].length() && i + k < str.length(); k++) {
+				for(int k = 0; k < search[j].length() && i + k < str.length(); k++) {
 					if(str.charAt(i + k) != search[j].charAt(k)) {
 						match = false;
 						break;
@@ -177,5 +185,13 @@ public class NoAllocStringReplace {
 			}
 		}
 		return false;
+
+		/*if(str == null || search == null)
+			return false;
+
+		return Stream.of(search)
+				.filter(Objects::nonNull)
+				.filter(s -> !s.isEmpty())
+				.anyMatch(str::contains);*/
 	}
 }

--- a/core/src/test/java/com/elefana/util/NoAllocStringReplaceTest.java
+++ b/core/src/test/java/com/elefana/util/NoAllocStringReplaceTest.java
@@ -1,0 +1,228 @@
+
+package com.elefana.util;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class NoAllocStringReplaceTest {
+
+    final String testString = "A test String";
+
+    @Test
+    public void testStringContainingSearchString() {
+        final String[] search = {"test"};
+        assertStringContainsSearch(testString, search);
+    }
+
+    @Test
+    public void testStringNotContainingSearchString() {
+        final String[] search = {"Not in here"};
+        assertStringDoesNotContainSearch(testString, search);
+    }
+
+    @Test
+    public void testStringContainingBothSearchStrings() {
+        final String[] search = { "A", "test" };
+        assertStringContainsSearch(testString, search);
+    }
+
+    @Test
+    public void testStringContainingOnlyOneSearchString() {
+        final String[] search = { "test", "Not in here" };
+        assertStringContainsSearch(testString, search);
+    }
+
+    @Test
+    public void testStringNotContainingBothSearchStrings() {
+        final String[] search = { "Not in here", "Also not there" };
+        assertStringDoesNotContainSearch(testString, search);
+    }
+
+    @Test
+    public void testSearchStringArrayIsEmpty() {
+        final String[] search = {};
+        assertStringDoesNotContainSearch(testString, search);
+    }
+
+    @Test
+    public void testSearchStringIsEmpty() {
+        final String[] search = { "" };
+        assertStringDoesNotContainSearch(testString, search);
+    }
+
+    @Test
+    public void testStringIsEmpty() {
+        final String emptyTestString = "";
+        final String[] search = { "test" };
+        assertStringDoesNotContainSearch(emptyTestString, search);
+    }
+
+    @Test
+    public void testStringIsNull() {
+        final String nullTestString = null;
+        final String[] search = { "test" };
+        assertStringDoesNotContainSearch(nullTestString, search);
+    }
+
+    @Test
+    public void testSearchStringArrayIsNull() {
+        final String[] search = null;
+        assertStringDoesNotContainSearch(testString, search);
+    }
+
+    @Test
+    public void testSearchStringIsNull() {
+        final String[] search = { null };
+        assertStringDoesNotContainSearch(testString, search);
+    }
+
+    @Test
+    public void testSearchStringIsIgnoredIfNull() {
+        final String[] search = { null, "test" };
+        assertStringContainsSearch(testString, search);
+    }
+
+    private void assertStringContainsSearch(String string, String [] search) {
+        Assert.assertTrue(NoAllocStringReplace.contains(string, search));
+    }
+
+    private void assertStringDoesNotContainSearch(String string, String [] search) {
+        Assert.assertFalse(NoAllocStringReplace.contains(string, search));
+    }
+
+    @Test
+    public void testReplace() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a l\nong string");
+        str.replaceAndEscapeUnicode(new String[] { "\n" }, new String[] { "\\\\n" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is a l\\\\nong string", ret);
+    }
+
+    @Test
+    public void testReplaceInTheEnd() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a long string foo");
+        str.replaceAndEscapeUnicode(new String[] { "foo" }, new String[] { "hello" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is a long string hello", ret);
+    }
+
+    @Test
+    public void testReplaceSmallerLengthInTheEnd() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a long string");
+        str.replaceAndEscapeUnicode(new String[] { "a long string" }, new String[] { "funny" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is funny", ret);
+    }
+
+    @Test
+    public void testReplaceSmallerLength() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a long string blah");
+        str.replaceAndEscapeUnicode(new String[] { "a long string" }, new String[] { "funny" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is funny blah", ret);
+    }
+
+    @Test
+    public void testReplaceMultiple() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a l\nong str\ning");
+        str.replaceAndEscapeUnicode(new String[] { "\n" }, new String[] { "\\\\n" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is a l\\\\nong str\\\\ning", ret);
+    }
+
+    @Test
+    public void testReplaceWithMultipleSearchStrings() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a l\nong str\ring");
+        str.replaceAndEscapeUnicode(new String[] { "\n", "\r" }, new String[] { "\\\\n", "\\\\r" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is a l\\\\nong str\\\\ring", ret);
+    }
+
+    @Test
+    public void testReplaceMultipleWithMultipleSearchStrings() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("thi\ns is\r a l\nong str\ring");
+        str.replaceAndEscapeUnicode(new String[] { "\n", "\r" }, new String[] { "\\\\n", "\\\\r" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("thi\\\\ns is\\\\r a l\\\\nong str\\\\ring", ret);
+    }
+
+    @Test
+    public void testEscapeUnicodeCharacter() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("abd\\u8932eeee");
+        str.replaceAndEscapeUnicode(new String[] { "b" }, new String[] { "xNewx" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("axNewxd\\\\u8932eeee", ret);
+    }
+
+    @Test
+    public void testEmptyString() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("");
+        str.replaceAndEscapeUnicode(new String[] { "b" }, new String[] { "xNewx" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("", ret);
+    }
+
+    @Test
+    public void testEmptyArrays() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a long string");
+        str.replaceAndEscapeUnicode(new String[] {  }, new String[] {  });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is a long string", ret);
+    }
+
+    @Test
+    public void testEmptyStringInSearchArray() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a long string");
+        str.replaceAndEscapeUnicode(new String[] { "" }, new String[] { "abc" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is a long string", ret);
+    }
+
+    @Test
+    public void testNullInSearchArray() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a long string");
+        str.replaceAndEscapeUnicode(new String[] { null }, new String[] { "abc" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is a long string", ret);
+    }
+
+    @Test
+    public void testNullInReplaceArray() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a long string");
+        str.replaceAndEscapeUnicode(new String[] { "a long" }, new String[] { null });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is a long string", ret);
+    }
+
+    @Test
+    public void testDelete() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate("this is a long string");
+        str.replaceAndEscapeUnicode(new String[] { "a long" }, new String[] { "" });
+        String ret = str.dispose();
+
+        Assert.assertEquals("this is  string", ret);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullString() {
+        NoAllocStringReplace str = NoAllocStringReplace.allocate(null);
+        str.replaceAndEscapeUnicode(new String[] { "b" }, new String[] { "xNewx" });
+        String ret = str.dispose();
+    }
+}


### PR DESCRIPTION
- added unit tests for NoAllocStringReplace
- added tests for null values in NoAllocStringReplace
- fixed a bug which occurs when the search term is longer than the
replace string, and the search term is located at the end of the
original string (see testReplaceSmallerLengthInTheEnd)