### PR TITLE
[#6] Fix Failing CoreIndexUtils test

### DIFF
--- a/core/src/main/java/com/elefana/util/CoreIndexUtils.java
+++ b/core/src/main/java/com/elefana/util/CoreIndexUtils.java
@@ -187,7 +187,7 @@ public class CoreIndexUtils implements IndexUtils {
 		return listIndicesForIndexPatternFromDatabase(indexPattern);
 	}
 
-	private List<String> listIndicesForIndexPatternFromDatabase(String indexPattern) throws ElefanaException {
+	public List<String> listIndicesForIndexPatternFromDatabase(String indexPattern) throws ElefanaException {
 		final List<String> results = listIndices();
 		final String[] patterns = indexPattern.split(",");
 

--- a/core/src/test/java/com/elefana/util/CoreIndexUtilsTest.java
+++ b/core/src/test/java/com/elefana/util/CoreIndexUtilsTest.java
@@ -15,7 +15,7 @@
  ******************************************************************************/
 package com.elefana.util;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -34,9 +34,9 @@ import com.elefana.api.exception.ElefanaException;
 
 public class CoreIndexUtilsTest {
 	private final CoreIndexUtils indexUtils = new CoreIndexUtils();
-	
+
 	private JdbcTemplate jdbcTemplate;
-	
+
 	@Before
 	public void setUp() {
 		jdbcTemplate = mock(JdbcTemplate.class);
@@ -85,12 +85,12 @@ public class CoreIndexUtilsTest {
 		final String todayMessageLogsPattern = "message-logs-2018-03-16*";
 		
 		when(jdbcTemplate.queryForList(anyString())).thenReturn(sqlRows);
-		
-		final List<String> allMessageLogs = indexUtils.listIndicesForIndexPattern(allMessageLogsPattern);
+
+		final List<String> allMessageLogs = indexUtils.listIndicesForIndexPatternFromDatabase(allMessageLogsPattern);
 		Assert.assertEquals(3, allMessageLogs.size());
 		Assert.assertEquals(indices, allMessageLogs);
 		
-		final List<String> todaysMessageLogs = indexUtils.listIndicesForIndexPattern(todayMessageLogsPattern);
+		final List<String> todaysMessageLogs = indexUtils.listIndicesForIndexPatternFromDatabase(todayMessageLogsPattern);
 		Assert.assertEquals(2, todaysMessageLogs.size());
 		Assert.assertEquals(false, todaysMessageLogs.contains("message-logs-2018-03-15t23:00:00"));
 	}


### PR DESCRIPTION
- Fixed test testListIndicesForIndexPattern by calling the non-cached
function listIndicesForIndexPatternFromDatabase instead of the cached
listIndicesForIndexPattern
- Remove usage of deprecated org.mockito.Matchers.anyString method