### PR TITLE
[#8] Make node stats refresh interval configurable

### DIFF
--- a/core/src/main/java/com/elefana/node/CoreNodeInfoService.java
+++ b/core/src/main/java/com/elefana/node/CoreNodeInfoService.java
@@ -82,9 +82,11 @@ public class CoreNodeInfoService implements NodeInfoService {
 			break;
 		}
 
-		scheduledExecutorService.scheduleAtFixedRate(jvmStats, 0L, 1L, TimeUnit.SECONDS);
-		scheduledExecutorService.scheduleAtFixedRate(osStats, 0L, 1L, TimeUnit.SECONDS);
-		scheduledExecutorService.scheduleAtFixedRate(processStats, 0L, 1L, TimeUnit.SECONDS);
+		long refreshInterval = environment.getProperty("elefana.service.node.statsRefreshInterval", Long.class, 1L);
+
+		scheduledExecutorService.scheduleAtFixedRate(jvmStats, 0L, refreshInterval, TimeUnit.SECONDS);
+		scheduledExecutorService.scheduleAtFixedRate(osStats, 0L, refreshInterval, TimeUnit.SECONDS);
+		scheduledExecutorService.scheduleAtFixedRate(processStats, 0L, refreshInterval, TimeUnit.SECONDS);
 	}
 
 	@PreDestroy

--- a/core/src/main/java/com/elefana/node/CoreNodeInfoService.java
+++ b/core/src/main/java/com/elefana/node/CoreNodeInfoService.java
@@ -1,6 +1,18 @@
-/**
- * Copyright 2018 Viridian Software Ltd.
- */
+/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
 package com.elefana.node;
 
 import com.elefana.api.json.EmptyJsonObject;

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -108,3 +108,7 @@ elefana.service.search.aggregation.threads=4
 # Determines no. of concurrently processed requests to template API
 # Defaults to no. of cores when commented out
 elefana.service.template.threads=4
+
+# Determines how many seconds elapse until statistics about nodes are re-fetched
+# Defaults to 1 second
+# elefana.service.node.statsRefreshInterval=1

--- a/uats-es2-citus/src/test/resources/es2.properties
+++ b/uats-es2-citus/src/test/resources/es2.properties
@@ -96,3 +96,7 @@ elefana.service.field.queue.io.interval=100
 # Determines no. of concurrently processed requests to template API
 # Defaults to no. of cores when commented out
 #elefana.service.template.threads=4
+
+# Determines how many seconds elapse until statistics about nodes are re-fetched
+# Defaults to 1 second
+# elefana.service.node.statsRefreshInterval=1

--- a/uats-es2/src/test/resources/es2.properties
+++ b/uats-es2/src/test/resources/es2.properties
@@ -97,3 +97,7 @@ elefana.service.field.queue.io.interval=100
 # Determines no. of concurrently processed requests to template API
 # Defaults to no. of cores when commented out
 #elefana.service.template.threads=4
+
+# Determines how many seconds elapse until statistics about nodes are re-fetched
+# Defaults to 1 second
+# elefana.service.node.statsRefreshInterval=1

--- a/uats-es5/src/test/resources/es5.properties
+++ b/uats-es5/src/test/resources/es5.properties
@@ -59,3 +59,7 @@ spring.datasource.tomcat.test-while-idle=true
 spring.datasource.tomcat.test-on-borrow=true
 spring.datasource.tomcat.validation-query=SELECT NOW();
 spring.datasource.tomcat.validation-interval=30000
+
+# Determines how many seconds elapse until statistics about nodes are re-fetched
+# Defaults to 1 second
+# elefana.service.node.statsRefreshInterval=1


### PR DESCRIPTION
`elefana.service.node.statsRefreshInterval` specifies how many **seconds**
elapse between fetching new node statistics.