### PR TITLE
#15 Make node stats compliant to elastic API

### DIFF
--- a/core/src/main/java/com/elefana/api/ApiRouter.java
+++ b/core/src/main/java/com/elefana/api/ApiRouter.java
@@ -415,7 +415,7 @@ public class ApiRouter {
 			switch (urlComponents[1]){
 				case "stats":
 					// _nodes/stats
-					return nodesService.prepareNodesInfo();
+					return nodesService.prepareAllNodesInfo();
 			}
 		case 3: {
 			if (urlComponents[2].equals("stats")) {
@@ -423,7 +423,7 @@ public class ApiRouter {
 				final String nodes = urlDecode(urlComponents[1]);
 				switch (nodes.toLowerCase()) {
 					case "_all":
-						return nodesService.prepareNodesInfo();
+						return nodesService.prepareAllNodesInfo();
 					case "_local":
 						return nodesService.prepareLocalNodeInfo();
 					default:
@@ -432,7 +432,7 @@ public class ApiRouter {
 			} else if (urlComponents[1].equals("stats")) {
 				// _nodes/stats/filters
 				final String[] filter = urlComponents[2].split(",");
-				return nodesService.prepareNodesInfo(new String[] {"_all"}, filter);
+				return nodesService.prepareAllNodesInfo(filter);
 			}
 		}
 		case 4: {
@@ -443,7 +443,7 @@ public class ApiRouter {
 					// _nodes/node ids/stats/filters
 					switch (nodes.toLowerCase()) {
 						case "_all":
-							return nodesService.prepareNodesInfo(filter);
+							return nodesService.prepareAllNodesInfo(filter);
 						case "_local":
 							return nodesService.prepareLocalNodeInfo(filter);
 						default:

--- a/core/src/main/java/com/elefana/api/ApiRouter.java
+++ b/core/src/main/java/com/elefana/api/ApiRouter.java
@@ -411,29 +411,44 @@ public class ApiRouter {
 	private ApiRequest<?> routeToNodeApi(HttpMethod method, String url, String[] urlComponents, String requestBody)
 			throws ElefanaException {
 		switch (urlComponents.length) {
-		case 1:
-			return nodesService.prepareNodesInfo();
-		case 2: {
-			final String nodes = urlDecode(urlComponents[1]);
-			switch (nodes.toLowerCase()) {
-			case "_all":
-				return nodesService.prepareNodesInfo();
-			case "_local":
-				return nodesService.prepareLocalNodeInfo();
-			default:
-				return nodesService.prepareNodesInfo(nodes.split(","));
+		case 2:
+			switch (urlComponents[1]){
+				case "stats":
+					// _nodes/stats
+					return nodesService.prepareNodesInfo();
+			}
+		case 3: {
+			if (urlComponents[2].equals("stats")) {
+				// _nodes/node ids/stats
+				final String nodes = urlDecode(urlComponents[1]);
+				switch (nodes.toLowerCase()) {
+					case "_all":
+						return nodesService.prepareNodesInfo();
+					case "_local":
+						return nodesService.prepareLocalNodeInfo();
+					default:
+						return nodesService.prepareNodesInfo(nodes.split(","));
+				}
+			} else if (urlComponents[1].equals("stats")) {
+				// _nodes/stats/filters
+				final String[] filter = urlComponents[2].split(",");
+				return nodesService.prepareNodesInfo(new String[] {"_all"}, filter);
 			}
 		}
-		case 3: {
+		case 4: {
 			final String nodes = urlDecode(urlComponents[1]);
-			final String[] filter = urlComponents[2].split(",");
-			switch (nodes.toLowerCase()) {
-			case "_all":
-				return nodesService.prepareNodesInfo(filter);
-			case "_local":
-				return nodesService.prepareLocalNodeInfo(filter);
-			default:
-				return nodesService.prepareNodesInfo(nodes.split(","), filter);
+			final String[] filter = urlComponents[3].split(",");
+			switch (urlComponents[2]) {
+				case "stats":
+					// _nodes/node ids/stats/filters
+					switch (nodes.toLowerCase()) {
+						case "_all":
+							return nodesService.prepareNodesInfo(filter);
+						case "_local":
+							return nodesService.prepareLocalNodeInfo(filter);
+						default:
+							return nodesService.prepareNodesInfo(nodes.split(","), filter);
+					}
 			}
 		}
 		}

--- a/core/src/main/java/com/elefana/node/NodesService.java
+++ b/core/src/main/java/com/elefana/node/NodesService.java
@@ -18,13 +18,15 @@ package com.elefana.node;
 import com.elefana.api.node.NodesInfoRequest;
 
 public interface NodesService {
-	
-	public NodesInfoRequest prepareNodesInfo();
-	
-	public NodesInfoRequest prepareNodesInfo(String [] filteredNodes);
+
+    public NodesInfoRequest prepareAllNodesInfo();
+
+    public NodesInfoRequest prepareNodesInfo(String [] filteredNodes);
 	
 	public NodesInfoRequest prepareNodesInfo(String [] filteredNodes, String[] infoFields);
-	
+
+	public NodesInfoRequest prepareAllNodesInfo(String[] infoFields);
+
 	public NodesInfoRequest prepareLocalNodeInfo();
 	
 	public NodesInfoRequest prepareLocalNodeInfo(String[] infoFields);

--- a/core/src/main/java/com/elefana/node/psql/PsqlNodesInfoRequest.java
+++ b/core/src/main/java/com/elefana/node/psql/PsqlNodesInfoRequest.java
@@ -50,9 +50,11 @@ public class PsqlNodesInfoRequest extends NodesInfoRequest implements Callable<N
 		if(getFilteredNodes() != null && getInfoFields() != null) {
 			return nodesService.getNodesInfo(getFilteredNodes(), getInfoFields());
 		} else if(getInfoFields() != null) {
+			return nodesService.getAllNodesInfo(getInfoFields());
+		} else if(getFilteredNodes() != null) {
 			return nodesService.getNodesInfo(getFilteredNodes());
 		} else {
-			return nodesService.getLocalNodeInfo();
+			return nodesService.getAllNodesInfo();
 		}
 	}
 }

--- a/uats-es2/src/test/java/com/elefana/es2/node/v2/V2JvmStatsTest.java
+++ b/uats-es2/src/test/java/com/elefana/es2/node/v2/V2JvmStatsTest.java
@@ -17,8 +17,6 @@
 package com.elefana.es2.node.v2;
 
 import com.elefana.ElefanaApplication;
-import com.elefana.node.JvmStats;
-import com.elefana.node.v2.V2JvmStats;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.hamcrest.Matcher;
@@ -33,7 +31,6 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.get;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.nullValue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { ElefanaApplication.class })
@@ -86,12 +83,18 @@ public class V2JvmStatsTest {
     }
 
     @Test
-    public void absenceWhenQueryingOsStats () {
+    public void absenceWhenQueryingOsStats() {
         Response global = get("/_nodes/stats/os");
         Map<String, ?> nodes = global.path("nodes");
         nodes.forEach((k, v) -> {
             checkIfJvmObjIsAbsent(global, "nodes.'" + k + "'.jvm");
         });
+    }
+
+    @Test
+    public void nodesEmptyWhenQueryingNonExistentID() {
+        get("/_nodes/thisNodeDoesNotExist/stats").then().body("nodes.isEmpty()", is(true));
+        get("/_nodes/thisNodeDoesNotExist/stats/jvm").then().body("nodes.isEmpty()", is(true));
     }
 
     private void checkIfJvmObjIsAbsent(Response response, String pathToJvmObj) {

--- a/uats-es2/src/test/java/com/elefana/es2/node/v2/V2OsStatsTest.java
+++ b/uats-es2/src/test/java/com/elefana/es2/node/v2/V2OsStatsTest.java
@@ -29,7 +29,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.Map;
 
 import static io.restassured.RestAssured.get;
-import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 @RunWith(SpringRunner.class)
@@ -87,6 +86,12 @@ public class V2OsStatsTest {
         nodes.forEach((k, v) -> {
             checkIfOsObjIsAbsent(global, "nodes." + k + ".os");
         });
+    }
+
+    @Test
+    public void nodesEmptyWhenQueryingNonExistentID() {
+        get("/_nodes/thisNodeDoesNotExist/stats").then().body("nodes.isEmpty()", is(true));
+        get("/_nodes/thisNodeDoesNotExist/stats/os").then().body("nodes.isEmpty()", is(true));
     }
 
     private void checkIfOsObjExists(Response response, String pathToOsObj) {

--- a/uats-es2/src/test/java/com/elefana/es2/node/v2/V2ProcessStatsTest.java
+++ b/uats-es2/src/test/java/com/elefana/es2/node/v2/V2ProcessStatsTest.java
@@ -30,7 +30,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.Map;
 
 import static io.restassured.RestAssured.get;
-import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 @RunWith(SpringRunner.class)
@@ -90,6 +89,12 @@ public class V2ProcessStatsTest {
         nodes.forEach((k, v) -> {
             checkIfProcessObjIsAbsent(global, "nodes." + k + ".process");
         });
+    }
+
+    @Test
+    public void nodesEmptyWhenQueryingNonExistentID() {
+        get("/_nodes/thisNodeDoesNotExist/stats").then().body("nodes.isEmpty()", is(true));
+        get("/_nodes/thisNodeDoesNotExist/stats/process").then().body("nodes.isEmpty()", is(true));
     }
 
     private void checkIfProcessObjExists(Response response, String pathToProcessObj) {


### PR DESCRIPTION
Elefana now only returns node stats data when the right url is queried.

`/_nodes/<node name>` will result in a `NoSuchAPIException` because this request is for the node info API. The right query is `/_nodes/<node name>/stats`, which is now correctly answered.

Furthermore the node selection works with:
- internal node id
- name
- address